### PR TITLE
Feature/13 implementation of sales crmcompanies

### DIFF
--- a/.build/Copy-WikiContent.ps1
+++ b/.build/Copy-WikiContent.ps1
@@ -1,0 +1,43 @@
+function Copy-WikiContent
+{
+    <#
+    .SYNOPSIS
+        Copies all files from a source directory (recursively) into a destination directory, flattening the structure.
+
+    .DESCRIPTION
+        The Copy-WikiContent function copies all files from the specified source directory and its subdirectories
+        into the specified destination directory. All files are placed directly in the destination directory,
+        and any existing files with the same name will be overwritten.
+
+    .PARAMETER SourcePath
+        The path to the source directory containing files to copy.
+
+    .PARAMETER DestinationPath
+        The path to the destination directory where files will be copied.
+
+    .EXAMPLE
+        Copy-WikiContent -SourcePath "C:\Docs\Wiki" -DestinationPath "C:\Build\WikiFlat"
+
+    .NOTES
+        If multiple files with the same name exist in different subdirectories, only the last one copied will remain.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$SourcePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationPath
+    )
+
+    if (-not (Test-Path -Path $DestinationPath))
+    {
+        New-Item -ItemType Directory -Path $DestinationPath | Out-Null
+    }
+
+    # Alle Dateien rekursiv holen und flach ins Ziel kopieren
+    Get-ChildItem -Path $SourcePath -File -Recurse | ForEach-Object {
+        $destFile = Join-Path $DestinationPath $_.Name
+        Copy-Item -Path $_.FullName -Destination $destFile -Force
+    }
+}

--- a/.build/Update-ChangelogDirect.ps1
+++ b/.build/Update-ChangelogDirect.ps1
@@ -1,0 +1,97 @@
+function Update-ChangelogDirect
+{
+    <#
+    .SYNOPSIS
+        Updates the CHANGELOG.md with the released version and pushes directly to main.
+
+    .DESCRIPTION
+        Replaces the [Unreleased] section header in CHANGELOG.md with the current
+        release version using the ChangelogManagement module, then commits and pushes
+        the change directly to the current branch without opening a pull request.
+
+        Pre-releases are skipped unless UpdateChangelogOnPrerelease is set to $true
+        in the GitHubConfig section of build.yaml.
+
+    .PARAMETER ModuleVersion
+        The semantic version of the module being released (e.g. '1.2.3').
+
+    .PARAMETER ChangelogPath
+        Absolute path to CHANGELOG.md.
+
+    .PARAMETER GitHubToken
+        Personal access token used to authenticate the git push.
+
+    .PARAMETER GitUserName
+        Git user.name to use for the commit.
+
+    .PARAMETER GitUserEmail
+        Git user.email to use for the commit.
+
+    .PARAMETER UpdateChangelogOnPrerelease
+        When $false (default), the function exits early if ModuleVersion contains a
+        pre-release tag (e.g. '1.2.3-preview1').
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [System.String]
+        $ModuleVersion,
+
+        [Parameter(Mandatory)]
+        [System.String]
+        $ChangelogPath,
+
+        [Parameter()]
+        [System.String]
+        $GitHubToken = '',
+
+        [Parameter()]
+        [System.String]
+        $GitUserName = '',
+
+        [Parameter()]
+        [System.String]
+        $GitUserEmail = '',
+
+        [Parameter()]
+        [System.Boolean]
+        $UpdateChangelogOnPrerelease = $false
+    )
+
+    if (-not $UpdateChangelogOnPrerelease -and $ModuleVersion -match '-')
+    {
+        Write-Build Yellow "Skipping CHANGELOG update for pre-release version '$ModuleVersion' (UpdateChangelogOnPrerelease is false)."
+        return
+    }
+
+    Write-Build DarkGray "Updating '$ChangelogPath' for release v$ModuleVersion"
+
+    Import-Module ChangelogManagement -ErrorAction Stop
+
+    Update-Changelog -ReleaseVersion $ModuleVersion -LinkMode None -Path $ChangelogPath
+
+    git config user.name $GitUserName
+    git config user.email $GitUserEmail
+
+    git add $ChangelogPath
+    git commit -m "Updating ChangeLog since v$ModuleVersion +semver:skip"
+
+    if ($GitHubToken)
+    {
+        $remoteUrl = (git remote get-url origin 2>$null).Trim()
+
+        if ($remoteUrl -match 'github\.com[:/](?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$')
+        {
+            $tokenUrl = "https://x-access-token`:$GitHubToken@github.com/$($Matches['owner'])/$($Matches['repo']).git"
+            git remote set-url origin $tokenUrl
+        }
+    }
+
+    git push origin HEAD
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "git push failed with exit code $LASTEXITCODE"
+    }
+    Write-Build Green "CHANGELOG.md updated and pushed directly to main for v$ModuleVersion"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### build.ps1
+- Introduced a new task `Update_Wiki_Home` that synchronizes the project `README.md` with the GitHub Wiki home page.
+  - Copies `README.md` content into `WikiContent/Home.md`.
+  - Automatically generates a `_Footer.md` file containing:
+    - The current UTC timestamp.
+    - The semantic version retrieved via `dotnet-gitversion`.
+  - Ensures the target wiki directory exists before writing files.
+  - Provides logging output and error handling for missing README scenarios.
+  - Enhances documentation consistency by keeping the wiki homepage aligned with the repository README.
+
+- Added a new task `Update_Changelog_Direct` to automate changelog updates during the build process.
+  - Invokes `Update-ChangelogDirect` with dynamically resolved parameters.
+  - Supports authentication via multiple environment variables (`GitHubToken`, `GITHUB_TOKEN`).
+  - Configures Git user identity from build configuration or environment variables.
+  - Adds support for conditional changelog updates on prerelease versions.
+  - Improves CI/CD automation by integrating changelog generation directly into the pipeline.
+
+### Changed
+
+#### build.yaml
+- Modified build workflow task execution:
+  - Disabled documentation generation steps (`Generate_Markdown_For_Public_Commands`, `Generate_MAML_from_built_module`) in the default build pipeline.
+  - Reordered and expanded wiki-related tasks:
+    - Added `Update_Wiki_Home` to ensure the wiki homepage is updated during documentation packaging.
+    - Adjusted placement of `Generate_Wiki_Sidebar_From_Ps1` for improved sequencing.
+    - Added optional hooks for custom wiki content handling.
+  - Updated `publish` pipeline sequence:
+    - Moved `Publish_GitHub_Wiki_Content` to run last, ensuring module publishing is not blocked by documentation issues.
+    - Introduced `Update_Changelog_Direct` before publishing to automate changelog updates as part of release flow.
+  - Removed the `updatedocs` workflow, simplifying the pipeline structure.
+
+- Updated configuration for `Publish_GitHub_Wiki_Content`:
+  - Disabled debug mode (`Debug: false`) to reduce verbosity in build output.
+
+
+## [0.6.0] - 2026-04-14
+
+### Added
+
 #### Companies
 - function Get-BrevoCompany - Retrieves a single company by ID or lists multiple companies with pagination and sorting
 - function New-BrevoCompany - Creates a new company with name and optional contact information

--- a/build.ps1
+++ b/build.ps1
@@ -330,6 +330,50 @@ process {
             Get-Error | out-string | write-host -foregroundcolor Yellow
         }
 
+        task Update_Wiki_Home {
+            $error.Clear()
+            Write-Output "TS: Update_Wiki_Home"
+            $readmePath = Join-Path $PSScriptRoot "README.md"
+            $homePath = Join-Path $OutputDirectory "WikiContent/Home.md"
+            $footerPath = Join-Path $OutputDirectory "WikiContent/_Footer.md"
+            $version = & dotnet-gitversion /showvariable SemVer
+            $date = Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+
+            if (Test-Path $readmePath) {
+                # Ensure the output directory exists
+                $wikiDir = Split-Path $homePath
+                if (-not (Test-Path $wikiDir)) {
+                    New-Item -ItemType Directory -Force -Path $wikiDir | Out-Null
+                }
+
+                Get-Content $readmePath | Out-File $homePath -Encoding UTF8
+
+                $footerLines = @(
+                    "**Last updated:** $date",
+                    "**Version:** $version",
+                    ""
+                )
+                $footerLines | Out-File $footerPath -Encoding UTF8
+
+                Write-Output "Updated Home.md and _Footer.md with version $version and date $date"
+            } else {
+                Write-Warning "README.md not found at $readmePath"
+            }
+            Get-Error | Out-String | Write-Host -ForegroundColor Yellow
+        }
+
+        task Update_Changelog_Direct {
+            . Set-SamplerTaskVariable
+
+            Update-ChangelogDirect `
+                -ModuleVersion $ModuleVersion `
+                -ChangelogPath (Get-SamplerAbsolutePath -Path 'CHANGELOG.md' -RelativeTo $ProjectPath) `
+                -GitHubToken ($env:GitHubToken ?? $env:GITHUB_TOKEN ?? '') `
+                -GitUserName ($BuildInfo.GitHubConfig.GitHubConfigUserName ?? $env:GIT_USER_NAME ?? '') `
+                -GitUserEmail ($BuildInfo.GitHubConfig.GitHubConfigUserEmail ?? $env:GIT_USER_EMAIL ?? '') `
+                -UpdateChangelogOnPrerelease ([bool] $BuildInfo.GitHubConfig.UpdateChangelogOnPrerelease)
+        }
+
         # Define default task sequence ("."), can be overridden in the $BuildInfo.
         task . {
             Write-Build -Object 'No sequence currently defined for the default task' -ForegroundColor Yellow

--- a/build.yaml
+++ b/build.yaml
@@ -52,8 +52,8 @@ BuildWorkflow:
     - Build_Module_ModuleBuilder
     - Build_NestedModules_ModuleBuilder
     - Create_changelog_release_output
-    - Generate_Markdown_For_Public_Commands
-    - Generate_MAML_from_built_module
+    # - Generate_Markdown_For_Public_Commands
+    # - Generate_MAML_from_built_module
 
   minibuild:
     - Clean
@@ -70,15 +70,13 @@ BuildWorkflow:
     # - Generate_External_Help_File_For_Public_Commands
     - Clean_Markdown_Of_Public_Commands
     # - Generate_Wiki_Sidebar
-    - Generate_Wiki_Sidebar_From_Ps1
     - Clean_Markdown_Metadata
+    # - Copy_Wiki_Content_Custom
+    - Generate_Wiki_Sidebar_From_Ps1
+    - Update_Wiki_Home
     - Package_Wiki_Content
 
-  updatedocs:
-    - Publish_GitHub_Wiki_Content
-
   sidebar:
-    # - Generate_Wiki_Sidebar_Custom
     - Generate_Wiki_Sidebar_From_Ps1
 
   pack:
@@ -106,9 +104,10 @@ BuildWorkflow:
   #- Merge_CodeCoverage_Files
 
   publish:
-    - Publish_GitHub_Wiki_Content # Runs first, if docs can't be generated, the release will fail
     - Publish_Release_To_GitHub
+    - Update_Changelog_Direct
     - publish_module_to_gallery
+    - Publish_GitHub_Wiki_Content #_Custom # Runs last to ensure that the module is published to the gallery, even if the wiki content is not updated.
 
 ####################################################
 #       PESTER  Configuration                      #
@@ -206,7 +205,7 @@ DscResource.DocGenerator:
   #     - '\*\*(.+?)\*\*' # Match bold
   #     - '\*(.+?)\*' # Match Italic (asterisk)
   Publish_GitHub_Wiki_Content:
-    Debug: true
+    Debug: false
   Generate_Wiki_Content:
     Generate_Markdown_For_Public_Commands:
       WithModulePage: true


### PR DESCRIPTION
### Added

#### build.ps1
- Introduced a new task `Update_Wiki_Home` that synchronizes the project `README.md` with the GitHub Wiki home page.
  - Copies `README.md` content into `WikiContent/Home.md`.
  - Automatically generates a `_Footer.md` file containing:
    - The current UTC timestamp.
    - The semantic version retrieved via `dotnet-gitversion`.
  - Ensures the target wiki directory exists before writing files.
  - Provides logging output and error handling for missing README scenarios.
  - Enhances documentation consistency by keeping the wiki homepage aligned with the repository README.

- Added a new task `Update_Changelog_Direct` to automate changelog updates during the build process.
  - Invokes `Update-ChangelogDirect` with dynamically resolved parameters.
  - Supports authentication via multiple environment variables (`GitHubToken`, `GITHUB_TOKEN`).
  - Configures Git user identity from build configuration or environment variables.
  - Adds support for conditional changelog updates on prerelease versions.
  - Improves CI/CD automation by integrating changelog generation directly into the pipeline.

### Changed

#### build.yaml
- Modified build workflow task execution:
  - Disabled documentation generation steps (`Generate_Markdown_For_Public_Commands`, `Generate_MAML_from_built_module`) in the default build pipeline.
  - Reordered and expanded wiki-related tasks:
    - Added `Update_Wiki_Home` to ensure the wiki homepage is updated during documentation packaging.
    - Adjusted placement of `Generate_Wiki_Sidebar_From_Ps1` for improved sequencing.
    - Added optional hooks for custom wiki content handling.
  - Updated `publish` pipeline sequence:
    - Moved `Publish_GitHub_Wiki_Content` to run last, ensuring module publishing is not blocked by documentation issues.
    - Introduced `Update_Changelog_Direct` before publishing to automate changelog updates as part of release flow.
  - Removed the `updatedocs` workflow, simplifying the pipeline structure.

- Updated configuration for `Publish_GitHub_Wiki_Content`:
  - Disabled debug mode (`Debug: false`) to reduce verbosity in build output.